### PR TITLE
Rest endpoints

### DIFF
--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -142,12 +142,11 @@ angular.module('starter.controllers', ['starter.services'])
   };
   var timer=$interval(function(){
         getDepartures();
-      },3000);
+      },30000);
   var getDepartures = function(){
     var deps = StopDeparture.query({stopId: $stateParams.stopId}, function(){
       var directions = deps[0].RouteDirections;
       $scope.departures = [];
-        console.log("refreshed!");
         for(var i = 0; i < directions.length; i++){
           if(directions[i].Departures.length !== 0 && !directions[i].IsDone){
             var departureNum = 0;

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -168,7 +168,9 @@ angular.module('starter.controllers', ['starter.services'])
     });
   } // end getDepartures
   $scope.stop = Stop.get({stopId: $stateParams.stopId});
-
+  $scope.$on('$destroy', function() {
+    $interval.cancel(timer);
+  });
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);
     $interval.cancel(timer);

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -102,7 +102,7 @@ angular.module('starter.controllers', ['starter.services'])
   });
 })
 
-.controller('RouteCtrl', function($scope, $stateParams, Route){
+.controller('RouteCtrl', function($scope, $stateParams, Route, RouteVehicles){
   var size = 0
   var route = Route.get({routeId: $stateParams.routeId}, function() {
     route.$save();
@@ -110,6 +110,7 @@ angular.module('starter.controllers', ['starter.services'])
   });
   $scope.route = route;
   $scope.groups = [];
+  $scope.vehicles = RouteVehicles.query({routeId: $stateParams.routeId});
   $scope.groups.push(route);
     $scope.groups[0] = {
     //  name: 'stops',
@@ -133,17 +134,37 @@ angular.module('starter.controllers', ['starter.services'])
   };
 })
 
-.controller('StopDeparturesController', function($scope, $stateParams, $resource, $location, Stop, moment, LatLong){
-  $scope.s = {};
-  var s = $resource('http://bustracker.pvta.com/infopoint/rest/stopdepartures/get/:stopId');
-  var x = s.query({stopId: $stateParams.stopId});
-  $scope.s = x;
-  var stop = Stop.get({stopId: $stateParams.stopId});
-  $scope.stopDetails = stop;
+.controller('StopDeparturesController', function($scope, $stateParams, $resource, $location, Stop, StopDeparture, moment, LatLong, getDepartureInfo){
+  
+  $scope.s = StopDeparture.query({stopId: $stateParams.stopId}, function(){
+    $scope.s = $scope.s || {RouteDirections: []};
+    var directions = $scope.s[0].RouteDirections;
+    for(var i = 0; i < directions.length; i++){
+      if (directions[i].IsDone) {
+        directions.splice(i, 1);
+    //    $scope.s = directions;
+      }
+      else{
+        var departureNum = 0;
+        var times = $scope.init(directions[i].Departures[departureNum].SDT, directions[i].Departures[departureNum].EDT);
+        while(times == 0){
+          $scope.init(directions[i].Departures[++departureNum].SDT, directions[i].Departures[++departureNum].EDT);
+        }
+        directions[i].StringifiedTimes = times;
+        //$scope.s = directions;
+      }
+      $scope.s = directions.sort(function(a, b){a.StringifiedTimes - b.StringifiedTimes});
+    }
+  });
+  $scope.stop = Stop.get({stopId: $stateParams.stopId});
   $scope.init = function(sdt, edt){
     $scope.sdtString = moment(sdt).fromNow();
     $scope.edtString = moment(edt).fromNow();
-    return {sdt: moment(sdt).fromNow(), edt: moment(edt).fromNow()}
+    if($scope.edtString.includes('ago')){
+      console.log("dsflkdjsf")
+      return 0;
+    }
+    else return {sdt: moment(sdt).fromNow(), edt: moment(edt).fromNow()}
   };
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -137,35 +137,37 @@ angular.module('starter.controllers', ['starter.services'])
 .controller('StopDeparturesController', function($scope, $stateParams, $resource, $location, Stop, StopDeparture, moment, LatLong, getDepartureInfo){
   
   $scope.s = StopDeparture.query({stopId: $stateParams.stopId}, function(){
-    $scope.s = $scope.s || {RouteDirections: []};
+   // $scope.s = $scope.s || {RouteDirections: []};
     var directions = $scope.s[0].RouteDirections;
+    $scope.z = [];
     for(var i = 0; i < directions.length; i++){
       if (directions[i].IsDone) {
         directions.splice(i, 1);
-    //    $scope.s = directions;
+        $scope.s = directions;
       }
-      else{
+      else if(directions[i].Departures.length !== 0 && !directions[i].IsDone){
         var departureNum = 0;
-        var times = $scope.init(directions[i].Departures[departureNum].SDT, directions[i].Departures[departureNum].EDT);
-        while(times == 0){
-          $scope.init(directions[i].Departures[++departureNum].SDT, directions[i].Departures[++departureNum].EDT);
+        console.log(directions[i].RouteId);
+        //var times = $scope.init(directions[i].Departures[departureNum].SDT, directions[i].Departures[departureNum].EDT);
+        var sdt = directions[i].Departures[departureNum].SDT;
+        var edt = directions[i].Departures[departureNum].EDT;
+        var times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
+        if(times.e.includes('ago')) console.log('true');
+        while(times.e.includes('ago')){
+          departureNum++;
+          sdt = directions[i].Departures[departureNum].SDT;
+          edt = directions[i].Departures[departureNum].EDT;
+          times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
         }
         directions[i].StringifiedTimes = times;
-        //$scope.s = directions;
+        var r = {route: directions[i].RouteId, trip: directions[i].Departures[departureNum].Trip, departures: times};
+        console.log(JSON.stringify(r));
+        $scope.z.push(r);
       }
-      $scope.s = directions.sort(function(a, b){a.StringifiedTimes - b.StringifiedTimes});
     }
   });
   $scope.stop = Stop.get({stopId: $stateParams.stopId});
-  $scope.init = function(sdt, edt){
-    $scope.sdtString = moment(sdt).fromNow();
-    $scope.edtString = moment(edt).fromNow();
-    if($scope.edtString.includes('ago')){
-      console.log("dsflkdjsf")
-      return 0;
-    }
-    else return {sdt: moment(sdt).fromNow(), edt: moment(edt).fromNow()}
-  };
+
   $scope.setCoordinates = function(lat, long){
     LatLong.push(lat, long);
     $location.path('/app/map')

--- a/www/js/controllers.js
+++ b/www/js/controllers.js
@@ -140,31 +140,33 @@ angular.module('starter.controllers', ['starter.services'])
    // $scope.s = $scope.s || {RouteDirections: []};
     var directions = $scope.s[0].RouteDirections;
     $scope.z = [];
-    for(var i = 0; i < directions.length; i++){
-      if (directions[i].IsDone) {
-        directions.splice(i, 1);
-        $scope.s = directions;
-      }
-      else if(directions[i].Departures.length !== 0 && !directions[i].IsDone){
-        var departureNum = 0;
-        console.log(directions[i].RouteId);
-        //var times = $scope.init(directions[i].Departures[departureNum].SDT, directions[i].Departures[departureNum].EDT);
-        var sdt = directions[i].Departures[departureNum].SDT;
-        var edt = directions[i].Departures[departureNum].EDT;
-        var times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
-        if(times.e.includes('ago')) console.log('true');
-        while(times.e.includes('ago')){
-          departureNum++;
-          sdt = directions[i].Departures[departureNum].SDT;
-          edt = directions[i].Departures[departureNum].EDT;
-          times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
+    var refresh = function(){
+      for(var i = 0; i < directions.length; i++){
+        if (directions[i].IsDone) {
+          directions.splice(i, 1);
+          $scope.s = directions;
         }
-        directions[i].StringifiedTimes = times;
-        var r = {route: directions[i].RouteId, trip: directions[i].Departures[departureNum].Trip, departures: times};
-        console.log(JSON.stringify(r));
-        $scope.z.push(r);
+        else if(directions[i].Departures.length !== 0 && !directions[i].IsDone){
+          var departureNum = 0;
+       //   console.log(directions[i].RouteId);
+          //var times = $scope.init(directions[i].Departures[departureNum].SDT, directions[i].Departures[departureNum].EDT);
+          var sdt = directions[i].Departures[departureNum].SDT;
+          var edt = directions[i].Departures[departureNum].EDT;
+          var times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
+          while(times.e.includes('ago')){
+            departureNum++;
+            sdt = directions[i].Departures[departureNum].SDT;
+            edt = directions[i].Departures[departureNum].EDT;
+            times = {s: moment(sdt).fromNow(), e: moment(edt).fromNow()};
+          }
+          directions[i].StringifiedTimes = times;
+          var r = {route: directions[i].RouteId, trip: directions[i].Departures[departureNum].Trip, departures: times};
+        //  console.log(JSON.stringify(r));
+          $scope.z.push(r);
+        }
       }
-    }
+    } // end refresh
+    refresh();
   });
   $scope.stop = Stop.get({stopId: $stateParams.stopId});
 

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -12,21 +12,51 @@ angular.module('starter.services', ['ngResource'])
     return $resource('http://bustracker.pvta.com/infopoint/rest/stops/get/:stopId');
 })
 
+.factory('RouteVehicles', function($resource){
+    return $resource('http://bustracker.pvta.com/infopoint/rest/vehicles/getallvehiclesforroute?routeId=:routeId')
+})
 
 .factory('StopDeparture', function ($resource) {
-    var x = $resource('http://bustracker.pvta.com/infopoint/rest/stopdepartures/get/:stopId');
-  console.log(JSON.stringify(x));
-    return x;
+    return $resource('http://bustracker.pvta.com/infopoint/rest/stopdepartures/get/:stopId');
+})
+
+.service('getDepartureInfo', function(){
   
-  /*var s = {StopId: 72};
-  var f = function ()
-  $http.get('http://bustracker.pvta.com/infopoint/rest/stopdepartures/get/:stopId').
-  then(function successCallback(response){
-    s = response.data;
-  }, function errorCallback(response){
-    console.log('uh oh');
-  });
-  return s;*/
+  //'STOLEN' FROM BUSINFOBOARD
+  return function getDepartureInfo(directions) {
+  // This is a little tricky. There's a sort of edge case where we want to
+  // display information for multiple buses on the same route, that are doing
+  // different things. We differentiate them by using their
+  // InternetServiceDesc, which will be different. Since the departures are
+  // ordered from soonest to furthest away, we care about the first one with
+  // a unique InternetServiceDesc, and that's what we're checking here.
+  var unique_ISDs = [];
+  departures = [];
+  var route_ids = [];
+  for (var i = 0; i < directions.length; i++) {
+    var direction = directions[i];
+    var route = routes[direction.RouteId];
+    for (var j = 0; j < direction.Departures.length; j++) {
+      var departure = direction.Departures[j];
+      //If the departure has a unique InternetServiceDesc,
+      if ($.inArray(departure.Trip.InternetServiceDesc, unique_ISDs) == -1
+          //and if it's in the allowed routes,
+          && (options.routes.length == 0 || $.inArray(route.ShortName, options.routes) != -1)
+          //and if it's not in the excluded trips
+          && (options.excluded_trips.length == 0 || $.inArray(departure.Trip.InternetServiceDesc, options.excluded_trips) == -1)
+          //and if it's in the future,
+          && moment(departure.EDT).isAfter(Date.now())) {
+        // then we push it to the list, and push its ISD to the unique ISDs list.
+        unique_ISDs.push(departure.Trip.InternetServiceDesc);
+        departures.push({Departure: departure, Route: route});
+        route_ids.push(route.RouteId);
+        // A global list of routes running on our stops
+        all_route_ids.push(route.RouteId);
+      }
+    }
+  }
+  return departures.sort(sort_function);
+}
 })
 
 .service('LatLong', function(){

--- a/www/js/services.js
+++ b/www/js/services.js
@@ -20,45 +20,6 @@ angular.module('starter.services', ['ngResource'])
     return $resource('http://bustracker.pvta.com/infopoint/rest/stopdepartures/get/:stopId');
 })
 
-.service('getDepartureInfo', function(){
-  
-  //'STOLEN' FROM BUSINFOBOARD
-  return function getDepartureInfo(directions) {
-  // This is a little tricky. There's a sort of edge case where we want to
-  // display information for multiple buses on the same route, that are doing
-  // different things. We differentiate them by using their
-  // InternetServiceDesc, which will be different. Since the departures are
-  // ordered from soonest to furthest away, we care about the first one with
-  // a unique InternetServiceDesc, and that's what we're checking here.
-  var unique_ISDs = [];
-  departures = [];
-  var route_ids = [];
-  for (var i = 0; i < directions.length; i++) {
-    var direction = directions[i];
-    var route = routes[direction.RouteId];
-    for (var j = 0; j < direction.Departures.length; j++) {
-      var departure = direction.Departures[j];
-      //If the departure has a unique InternetServiceDesc,
-      if ($.inArray(departure.Trip.InternetServiceDesc, unique_ISDs) == -1
-          //and if it's in the allowed routes,
-          && (options.routes.length == 0 || $.inArray(route.ShortName, options.routes) != -1)
-          //and if it's not in the excluded trips
-          && (options.excluded_trips.length == 0 || $.inArray(departure.Trip.InternetServiceDesc, options.excluded_trips) == -1)
-          //and if it's in the future,
-          && moment(departure.EDT).isAfter(Date.now())) {
-        // then we push it to the list, and push its ISD to the unique ISDs list.
-        unique_ISDs.push(departure.Trip.InternetServiceDesc);
-        departures.push({Departure: departure, Route: route});
-        route_ids.push(route.RouteId);
-        // A global list of routes running on our stops
-        all_route_ids.push(route.RouteId);
-      }
-    }
-  }
-  return departures.sort(sort_function);
-}
-})
-
 .service('LatLong', function(){
   var latlong = [];
   return {

--- a/www/templates/route.html
+++ b/www/templates/route.html
@@ -8,13 +8,12 @@
    <div class="item item-body">
      <h3>Buses on this route</h3>
      <ion-list>
-      <ion-item ng-repeat="vehicle in route.Vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}">
+      <ion-item ng-repeat="vehicle in vehicles" href="#/app/vehicles/{{vehicle.VehicleId}}">
         <h4>Bus {{vehicle.Name}}</h4>
         <p>Last Stop: <b>{{vehicle.LastStop? vehicle.LastStop : "none specified"}}</b></p>
         <p>Headed <b>{{vehicle.Direction? vehicle.Direction : "in an ungiven direction"}}</b> toward <b>{{vehicle.Destination ? vehicle.Destination : "an unreported destination"}}</b></p>
       </ion-item>
      </ion-list>
-     
      
      <ion-list>
         <div ng-repeat="group in groups">

--- a/www/templates/stop_departures.html
+++ b/www/templates/stop_departures.html
@@ -3,17 +3,16 @@
     <div class="list card">
       <div class="item">
         <h3>Stop {{stop.StopId}}: {{stop.Name}}</h3>
-        <button class="button button-positive" ng-click="setCoordinates(stopDetails.Latitude,
-                  stopDetails.Longitude)" ng-href="/app/map">View this stop on a map</button>
+        <button class="button button-positive" ng-click="setCoordinates(stop.Latitude,
+                  stop.Longitude)" ng-href="/app/map">View this stop on a map</button>
       </div>
    <div class="item item-body">
      <h3>Next Departures at this stop</h3>
      <ion-list>
-      <ion-item ng-repeat="routeDirection in s">
-        <h2>{{routeDirection.Departures[0].Trip.InternetServiceDesc}}</h2>
-        <h1>Scheduled {{routeDirection.StringifiedTimes.edt}}</h1>
-        <h1>Estimated {{routeDirection.StringifiedTimes.sdt}}</h1>
-        <p>Unit: {{routeDirection.Departures[0].Trip.RunId}}</p>
+      <ion-item ng-repeat="route in z">
+        <h2>{{route.trip.InternetServiceDesc}}</h2>
+        <h2>Scheduled in {{route.departures.s}}</h2>
+        <h2>Estimated in {{route.departures.e}}</h2>
       </ion-item>
      </ion-list>
       </div>

--- a/www/templates/stop_departures.html
+++ b/www/templates/stop_departures.html
@@ -2,18 +2,17 @@
   <ion-content>
     <div class="list card">
       <div class="item">
-        <h3>Stop {{s[0].StopId}}: {{stopDetails.Name}}</h3>
+        <h3>Stop {{stop.StopId}}: {{stop.Name}}</h3>
         <button class="button button-positive" ng-click="setCoordinates(stopDetails.Latitude,
                   stopDetails.Longitude)" ng-href="/app/map">View this stop on a map</button>
       </div>
    <div class="item item-body">
      <h3>Next Departures at this stop</h3>
      <ion-list>
-      <ion-item ng-repeat="routeDirection in s[0].RouteDirections">
-        {{init(routeDirection.Departures[0].SDT, routeDirection.Departures[0].EDT);""}}
+      <ion-item ng-repeat="routeDirection in s">
         <h2>{{routeDirection.Departures[0].Trip.InternetServiceDesc}}</h2>
-        <h3>Scheduled: {{sdtString}}</h3>
-        <h3>Estimated: {{edtString}}</h3>
+        <h1>Scheduled {{routeDirection.StringifiedTimes.edt}}</h1>
+        <h1>Estimated {{routeDirection.StringifiedTimes.sdt}}</h1>
         <p>Unit: {{routeDirection.Departures[0].Trip.RunId}}</p>
       </ion-item>
      </ion-list>

--- a/www/templates/stop_departures.html
+++ b/www/templates/stop_departures.html
@@ -1,3 +1,4 @@
+<meta http-equiv="refresh" content="30" />
 <ion-view view-title="Stop Departures">
   <ion-content>
     <div class="list card">
@@ -11,8 +12,8 @@
      <ion-list>
       <ion-item ng-repeat="route in z">
         <h2>{{route.trip.InternetServiceDesc}}</h2>
-        <h2>Scheduled in {{route.departures.s}}</h2>
-        <h2>Estimated in {{route.departures.e}}</h2>
+        <h2>Scheduled {{route.departures.s}}</h2>
+        <h2>Estimated {{route.departures.e}}</h2>
       </ion-item>
      </ion-list>
       </div>

--- a/www/templates/stop_departures.html
+++ b/www/templates/stop_departures.html
@@ -1,4 +1,3 @@
-<meta http-equiv="refresh" content="30" />
 <ion-view view-title="Stop Departures">
   <ion-content>
     <div class="list card">
@@ -10,7 +9,7 @@
    <div class="item item-body">
      <h3>Next Departures at this stop</h3>
      <ion-list>
-      <ion-item ng-repeat="route in z">
+      <ion-item ng-repeat="route in departures">
         <h2>{{route.trip.InternetServiceDesc}}</h2>
         <h2>Scheduled {{route.departures.s}}</h2>
         <h2>Estimated {{route.departures.e}}</h2>


### PR DESCRIPTION
The name of this PR is misleading; I changed the URL we're using in one case, but mainly this covers <b>Stop Departures</b>. 

There is little change from the user's perspective, but the functional difference is significant.  We now are:

1. Properly displaying all Departures per stop
2. NOT attempting to display Departures for routes that are finished servicing that stop for the evening.
3. Handing the parsing of all the data returned by Avail in JS instead of HTML.  Thus, the template has been greatly reduced in size.
4. Auto-refreshing the list of Departures for the Stop in question every 30 seconds, and NOT doing so after that page leaves focus.